### PR TITLE
Bump version numbers to 4.1.0-SNAPSHOT, and change move packages to org.semanticweb.owlapitools if they weren't in a more sensible place 

### DIFF
--- a/atomicdecomposition/pom.xml
+++ b/atomicdecomposition/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>net.sourceforge.owlapi</groupId>
 		<artifactId>owlapitools-parent</artifactId>
-		<version>4.0.1</version>
+		<version>4.1.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 </project>

--- a/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/AtomList.java
+++ b/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/AtomList.java
@@ -1,4 +1,4 @@
-package decomposition;
+package org.semanticweb.owlapitools.decomposition;
 
 import java.util.ArrayList;
 import java.util.HashSet;

--- a/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/AxiomSelector.java
+++ b/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/AxiomSelector.java
@@ -1,13 +1,13 @@
-package decomposition;
-
-import static org.semanticweb.owlapi.model.AxiomType.AXIOM_TYPES;
-
-import java.util.ArrayList;
-import java.util.List;
+package org.semanticweb.owlapitools.decomposition;
 
 import org.semanticweb.owlapi.model.AxiomType;
 import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLOntology;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.semanticweb.owlapi.model.AxiomType.AXIOM_TYPES;
 
 /**
  * A filter for axioms

--- a/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/AxiomWrapper.java
+++ b/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/AxiomWrapper.java
@@ -1,4 +1,4 @@
-package decomposition;
+package org.semanticweb.owlapitools.decomposition;
 
 import org.semanticweb.owlapi.model.OWLAxiom;
 

--- a/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/BotEquivalenceEvaluator.java
+++ b/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/BotEquivalenceEvaluator.java
@@ -1,4 +1,4 @@
-package decomposition;
+package org.semanticweb.owlapitools.decomposition;
 
 import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLClassExpression;

--- a/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/Decomposer.java
+++ b/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/Decomposer.java
@@ -1,4 +1,4 @@
-package decomposition;
+package org.semanticweb.owlapitools.decomposition;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/IdentityMultiMap.java
+++ b/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/IdentityMultiMap.java
@@ -1,4 +1,4 @@
-package decomposition;
+package org.semanticweb.owlapitools.decomposition;
 
 import java.io.Serializable;
 import java.util.ArrayList;

--- a/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/LocalityChecker.java
+++ b/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/LocalityChecker.java
@@ -1,4 +1,4 @@
-package decomposition;
+package org.semanticweb.owlapitools.decomposition;
 
 import java.util.Collection;
 

--- a/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/Modularizer.java
+++ b/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/Modularizer.java
@@ -1,4 +1,4 @@
-package decomposition;
+package org.semanticweb.owlapitools.decomposition;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;

--- a/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/OntologyAtom.java
+++ b/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/OntologyAtom.java
@@ -1,4 +1,4 @@
-package decomposition;
+package org.semanticweb.owlapitools.decomposition;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/SemanticLocalityChecker.java
+++ b/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/SemanticLocalityChecker.java
@@ -1,4 +1,4 @@
-package decomposition;
+package org.semanticweb.owlapitools.decomposition;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/SigAccessor.java
+++ b/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/SigAccessor.java
@@ -1,4 +1,4 @@
-package decomposition;
+package org.semanticweb.owlapitools.decomposition;
 
 import org.semanticweb.owlapi.model.OWLDataRange;
 import org.semanticweb.owlapi.util.OWLObjectVisitorAdapter;

--- a/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/SigIndex.java
+++ b/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/SigIndex.java
@@ -1,4 +1,4 @@
-package decomposition;
+package org.semanticweb.owlapitools.decomposition;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/Signature.java
+++ b/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/Signature.java
@@ -1,4 +1,4 @@
-package decomposition;
+package org.semanticweb.owlapitools.decomposition;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/SyntacticLocalityChecker.java
+++ b/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/SyntacticLocalityChecker.java
@@ -1,52 +1,9 @@
-package decomposition;
+package org.semanticweb.owlapitools.decomposition;
+
+import org.semanticweb.owlapi.model.*;
 
 import java.util.Collection;
 import java.util.Set;
-
-import org.semanticweb.owlapi.model.OWLAnnotationAssertionAxiom;
-import org.semanticweb.owlapi.model.OWLAnnotationPropertyDomainAxiom;
-import org.semanticweb.owlapi.model.OWLAnnotationPropertyRangeAxiom;
-import org.semanticweb.owlapi.model.OWLAsymmetricObjectPropertyAxiom;
-import org.semanticweb.owlapi.model.OWLAxiom;
-import org.semanticweb.owlapi.model.OWLAxiomVisitor;
-import org.semanticweb.owlapi.model.OWLClassAssertionAxiom;
-import org.semanticweb.owlapi.model.OWLClassExpression;
-import org.semanticweb.owlapi.model.OWLDataPropertyAssertionAxiom;
-import org.semanticweb.owlapi.model.OWLDataPropertyDomainAxiom;
-import org.semanticweb.owlapi.model.OWLDataPropertyRangeAxiom;
-import org.semanticweb.owlapi.model.OWLDatatypeDefinitionAxiom;
-import org.semanticweb.owlapi.model.OWLDeclarationAxiom;
-import org.semanticweb.owlapi.model.OWLDifferentIndividualsAxiom;
-import org.semanticweb.owlapi.model.OWLDisjointClassesAxiom;
-import org.semanticweb.owlapi.model.OWLDisjointDataPropertiesAxiom;
-import org.semanticweb.owlapi.model.OWLDisjointObjectPropertiesAxiom;
-import org.semanticweb.owlapi.model.OWLDisjointUnionAxiom;
-import org.semanticweb.owlapi.model.OWLEquivalentClassesAxiom;
-import org.semanticweb.owlapi.model.OWLEquivalentDataPropertiesAxiom;
-import org.semanticweb.owlapi.model.OWLEquivalentObjectPropertiesAxiom;
-import org.semanticweb.owlapi.model.OWLFunctionalDataPropertyAxiom;
-import org.semanticweb.owlapi.model.OWLFunctionalObjectPropertyAxiom;
-import org.semanticweb.owlapi.model.OWLHasKeyAxiom;
-import org.semanticweb.owlapi.model.OWLInverseFunctionalObjectPropertyAxiom;
-import org.semanticweb.owlapi.model.OWLInverseObjectPropertiesAxiom;
-import org.semanticweb.owlapi.model.OWLIrreflexiveObjectPropertyAxiom;
-import org.semanticweb.owlapi.model.OWLNegativeDataPropertyAssertionAxiom;
-import org.semanticweb.owlapi.model.OWLNegativeObjectPropertyAssertionAxiom;
-import org.semanticweb.owlapi.model.OWLObject;
-import org.semanticweb.owlapi.model.OWLObjectPropertyAssertionAxiom;
-import org.semanticweb.owlapi.model.OWLObjectPropertyDomainAxiom;
-import org.semanticweb.owlapi.model.OWLObjectPropertyExpression;
-import org.semanticweb.owlapi.model.OWLObjectPropertyRangeAxiom;
-import org.semanticweb.owlapi.model.OWLReflexiveObjectPropertyAxiom;
-import org.semanticweb.owlapi.model.OWLSameIndividualAxiom;
-import org.semanticweb.owlapi.model.OWLSubAnnotationPropertyOfAxiom;
-import org.semanticweb.owlapi.model.OWLSubClassOfAxiom;
-import org.semanticweb.owlapi.model.OWLSubDataPropertyOfAxiom;
-import org.semanticweb.owlapi.model.OWLSubObjectPropertyOfAxiom;
-import org.semanticweb.owlapi.model.OWLSubPropertyChainOfAxiom;
-import org.semanticweb.owlapi.model.OWLSymmetricObjectPropertyAxiom;
-import org.semanticweb.owlapi.model.OWLTransitiveObjectPropertyAxiom;
-import org.semanticweb.owlapi.model.SWRLRule;
 
 /** syntactic locality checker for DL axioms */
 public class SyntacticLocalityChecker implements OWLAxiomVisitor,

--- a/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/TopEquivalenceEvaluator.java
+++ b/atomicdecomposition/src/main/java/org/semanticweb/owlapitools/decomposition/TopEquivalenceEvaluator.java
@@ -1,4 +1,4 @@
-package decomposition;
+package org.semanticweb.owlapitools.decomposition;
 
 import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLClassExpression;

--- a/atomicdecomposition/src/main/java/uk/ac/manchester/cs/atomicdecomposition/AtomicDecomposerOWLAPITOOLS.java
+++ b/atomicdecomposition/src/main/java/uk/ac/manchester/cs/atomicdecomposition/AtomicDecomposerOWLAPITOOLS.java
@@ -1,29 +1,15 @@
 package uk.ac.manchester.cs.atomicdecomposition;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.Multimap;
+import org.semanticweb.owlapitools.decomposition.*;
 import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLEntity;
 import org.semanticweb.owlapi.model.OWLOntology;
-
 import uk.ac.manchester.cs.chainsaw.FastSet;
 import uk.ac.manchester.cs.owlapi.modularity.ModuleType;
 
-import com.google.common.collect.LinkedHashMultimap;
-import com.google.common.collect.Multimap;
-
-import decomposition.AxiomSelector;
-import decomposition.AxiomWrapper;
-import decomposition.Decomposer;
-import decomposition.IdentityMultiMap;
-import decomposition.OntologyAtom;
-import decomposition.SyntacticLocalityChecker;
+import java.util.*;
 
 /** atomc decomposition implementation */
 public class AtomicDecomposerOWLAPITOOLS implements AtomicDecomposition {

--- a/atomicdecomposition/src/test/java/org/semanticweb/owlapitools/decomposition/test/AtomicDecomposerDepedenciesTest.java
+++ b/atomicdecomposition/src/test/java/org/semanticweb/owlapitools/decomposition/test/AtomicDecomposerDepedenciesTest.java
@@ -1,21 +1,16 @@
-package decomposition.test;
-
-import static org.junit.Assert.*;
-
-import java.util.Set;
+package org.semanticweb.owlapitools.decomposition.test;
 
 import org.junit.Test;
 import org.semanticweb.owlapi.apibinding.OWLManager;
-import org.semanticweb.owlapi.model.IRI;
-import org.semanticweb.owlapi.model.OWLClass;
-import org.semanticweb.owlapi.model.OWLDataFactory;
-import org.semanticweb.owlapi.model.OWLOntology;
-import org.semanticweb.owlapi.model.OWLOntologyCreationException;
-import org.semanticweb.owlapi.model.OWLOntologyManager;
-
+import org.semanticweb.owlapi.model.*;
 import uk.ac.manchester.cs.atomicdecomposition.Atom;
 import uk.ac.manchester.cs.atomicdecomposition.AtomicDecomposerOWLAPITOOLS;
 import uk.ac.manchester.cs.atomicdecomposition.AtomicDecomposition;
+
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 @SuppressWarnings("javadoc")
 public class AtomicDecomposerDepedenciesTest {

--- a/atomicdecomposition/src/test/java/org/semanticweb/owlapitools/decomposition/test/SemanticLocalityTestCase.java
+++ b/atomicdecomposition/src/test/java/org/semanticweb/owlapitools/decomposition/test/SemanticLocalityTestCase.java
@@ -1,22 +1,21 @@
 package org.semanticweb.owlapitools.decomposition.test;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.model.*;
+import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
+import org.semanticweb.owlapitools.decomposition.AxiomWrapper;
+import org.semanticweb.owlapitools.decomposition.SemanticLocalityChecker;
+import org.semanticweb.owlapitools.decomposition.Signature;
 
+import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.annotation.Nonnull;
-
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.semanticweb.owlapitools.decomposition.SemanticLocalityChecker;
-import org.semanticweb.owlapi.apibinding.OWLManager;
-import org.semanticweb.owlapi.model.*;
-import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
-
-import org.semanticweb.owlapitools.decomposition.AxiomWrapper;
+import static org.junit.Assert.assertEquals;
 
 @Ignore
 @SuppressWarnings("javadoc")

--- a/atomicdecomposition/src/test/java/org/semanticweb/owlapitools/decomposition/test/SemanticLocalityTestCase.java
+++ b/atomicdecomposition/src/test/java/org/semanticweb/owlapitools/decomposition/test/SemanticLocalityTestCase.java
@@ -1,4 +1,4 @@
-package decomposition.test;
+package org.semanticweb.owlapitools.decomposition.test;
 
 import static org.junit.Assert.assertEquals;
 
@@ -11,6 +11,7 @@ import javax.annotation.Nonnull;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.semanticweb.owlapitools.decomposition.SemanticLocalityChecker;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLAnnotationProperty;
@@ -28,8 +29,7 @@ import org.semanticweb.owlapi.model.OWLObjectProperty;
 import org.semanticweb.owlapi.model.OWLSubClassOfAxiom;
 import org.semanticweb.owlapi.model.SWRLAtom;
 
-import decomposition.AxiomWrapper;
-import decomposition.SemanticLocalityChecker;
+import org.semanticweb.owlapitools.decomposition.AxiomWrapper;
 
 @Ignore
 @SuppressWarnings("javadoc")

--- a/atomicdecomposition/src/test/java/org/semanticweb/owlapitools/decomposition/test/SyntacticLocalityTestCase.java
+++ b/atomicdecomposition/src/test/java/org/semanticweb/owlapitools/decomposition/test/SyntacticLocalityTestCase.java
@@ -1,4 +1,4 @@
-package decomposition.test;
+package org.semanticweb.owlapitools.decomposition.test;
 
 import static org.junit.Assert.assertEquals;
 
@@ -8,8 +8,12 @@ import java.util.Set;
 
 import javax.annotation.Nonnull;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.semanticweb.owlapitools.decomposition.AxiomWrapper;
+import org.semanticweb.owlapitools.decomposition.Signature;
+import org.semanticweb.owlapitools.decomposition.SyntacticLocalityChecker;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLAnnotationProperty;
@@ -26,10 +30,6 @@ import org.semanticweb.owlapi.model.OWLNamedIndividual;
 import org.semanticweb.owlapi.model.OWLObjectProperty;
 import org.semanticweb.owlapi.model.OWLSubClassOfAxiom;
 import org.semanticweb.owlapi.model.SWRLAtom;
-
-import decomposition.AxiomWrapper;
-import decomposition.Signature;
-import decomposition.SyntacticLocalityChecker;
 
 @SuppressWarnings("javadoc")
 public class SyntacticLocalityTestCase {
@@ -478,7 +478,7 @@ public class SyntacticLocalityTestCase {
     public void shouldResetSignature() {
         OWLSubClassOfAxiom ax = df.getOWLSubClassOfAxiom(a, b);
         testSubject.preprocessOntology(Arrays.asList(new AxiomWrapper(ax)));
-        assertEquals(ax.getSignature(), testSubject.getSignature()
+        Assert.assertEquals(ax.getSignature(), testSubject.getSignature()
                 .getSignature());
     }
 

--- a/comparator/src/main/java/utils/reasonercomparator/Checker.java
+++ b/comparator/src/main/java/utils/reasonercomparator/Checker.java
@@ -1,4 +1,4 @@
-package utils.reasonercomparator;
+package org.semanticweb.owlapitools.utils.reasonercomparator;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;

--- a/comparator/src/main/java/utils/reasonercomparator/Column.java
+++ b/comparator/src/main/java/utils/reasonercomparator/Column.java
@@ -1,4 +1,4 @@
-package utils.reasonercomparator;
+package org.semanticweb.owlapitools.utils.reasonercomparator;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/comparator/src/main/java/utils/reasonercomparator/ComparatorReasonerFactory.java
+++ b/comparator/src/main/java/utils/reasonercomparator/ComparatorReasonerFactory.java
@@ -6,7 +6,7 @@
  * copyright 2012, Ignazio Palmisano, University of Manchester
  *
  */
-package utils.reasonercomparator;
+package org.semanticweb.owlapitools.utils.reasonercomparator;
 
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.reasoner.IllegalConfigurationException;

--- a/comparator/src/main/java/utils/reasonercomparator/ComparisonExecutor.java
+++ b/comparator/src/main/java/utils/reasonercomparator/ComparisonExecutor.java
@@ -1,4 +1,4 @@
-package utils.reasonercomparator;
+package org.semanticweb.owlapitools.utils.reasonercomparator;
 
 import static org.junit.Assert.assertTrue;
 

--- a/comparator/src/main/java/utils/reasonercomparator/ComparisonReasoner.java
+++ b/comparator/src/main/java/utils/reasonercomparator/ComparisonReasoner.java
@@ -6,9 +6,9 @@
  * copyright 2012, Ignazio Palmisano, University of Manchester
  *
  */
-package utils.reasonercomparator;
+package org.semanticweb.owlapitools.utils.reasonercomparator;
 
-import static utils.reasonercomparator.MethodNames.*;
+import static org.semanticweb.owlapitools.utils.reasonercomparator.MethodNames.*;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;

--- a/comparator/src/main/java/utils/reasonercomparator/MethodNames.java
+++ b/comparator/src/main/java/utils/reasonercomparator/MethodNames.java
@@ -1,4 +1,4 @@
-package utils.reasonercomparator;
+package org.semanticweb.owlapitools.utils.reasonercomparator;
 
 /** methods to measure */
 public enum MethodNames {

--- a/comparator/src/main/java/utils/reasonercomparator/OntologyLoader.java
+++ b/comparator/src/main/java/utils/reasonercomparator/OntologyLoader.java
@@ -1,4 +1,4 @@
-package utils.reasonercomparator;
+package org.semanticweb.owlapitools.utils.reasonercomparator;
 
 import java.io.File;
 import java.io.FilenameFilter;

--- a/comparator/src/main/java/utils/reasonercomparator/PerformanceComparator.java
+++ b/comparator/src/main/java/utils/reasonercomparator/PerformanceComparator.java
@@ -1,4 +1,4 @@
-package utils.reasonercomparator;
+package org.semanticweb.owlapitools.utils.reasonercomparator;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/comparator/src/main/java/utils/reasonercomparator/PooledOWLReasoner.java
+++ b/comparator/src/main/java/utils/reasonercomparator/PooledOWLReasoner.java
@@ -6,7 +6,7 @@
  * copyright 2012, Ignazio Palmisano, University of Manchester
  *
  */
-package utils.reasonercomparator;
+package org.semanticweb.owlapitools.utils.reasonercomparator;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/comparator/src/main/java/utils/reasonercomparator/ReasonerPerformanceResult.java
+++ b/comparator/src/main/java/utils/reasonercomparator/ReasonerPerformanceResult.java
@@ -1,4 +1,4 @@
-package utils.reasonercomparator;
+package org.semanticweb.owlapitools.utils.reasonercomparator;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/concurrentimpl/pom.xml
+++ b/concurrentimpl/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>net.sourceforge.owlapi</groupId>
 		<artifactId>owlapitools-parent</artifactId>
-		<version>4.0.1</version>
+		<version>4.1.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 </project>

--- a/concurrentimpl/src/main/java/org/semanticweb/owlapitools/cachedreasoner/CachedOWLReasoner.java
+++ b/concurrentimpl/src/main/java/org/semanticweb/owlapitools/cachedreasoner/CachedOWLReasoner.java
@@ -6,7 +6,7 @@
  * copyright 2012, Ignazio Palmisano, University of Manchester
  *
  */
-package utils.cachedreasoner;
+package org.semanticweb.owlapitools.cachedreasoner;
 
 import static org.semanticweb.owlapi.util.OWLAPIPreconditions.verifyNotNull;
 

--- a/concurrentimpl/src/main/java/org/semanticweb/owlapitools/cachedreasoner/CachedReasonerFactory.java
+++ b/concurrentimpl/src/main/java/org/semanticweb/owlapitools/cachedreasoner/CachedReasonerFactory.java
@@ -1,4 +1,4 @@
-package utils.cachedreasoner;
+package org.semanticweb.owlapitools.cachedreasoner;
 
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.reasoner.IllegalConfigurationException;

--- a/concurrentimpl/src/main/java/org/semanticweb/owlapitools/threadedreasoner/ThreadedReasoner.java
+++ b/concurrentimpl/src/main/java/org/semanticweb/owlapitools/threadedreasoner/ThreadedReasoner.java
@@ -6,7 +6,7 @@
  * copyright 2012, Ignazio Palmisano, University of Manchester
  *
  */
-package utils.threadedreasoner;
+package org.semanticweb.owlapitools.threadedreasoner;
 
 import java.util.List;
 import java.util.Set;

--- a/concurrentimpl/src/main/java/org/semanticweb/owlapitools/utils/Bag.java
+++ b/concurrentimpl/src/main/java/org/semanticweb/owlapitools/utils/Bag.java
@@ -1,4 +1,4 @@
-package utils;
+package org.semanticweb.owlapitools.utils;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 	<groupId>net.sourceforge.owlapi</groupId>
 	<artifactId>owlapitools-parent</artifactId>
 	<packaging>pom</packaging>
-	<version>4.0.1</version>
+	<version>4.1.0-SNAPSHOT</version>
 	<name>OWLAPI_TOOLS</name>
 	<description>OWLAPI_TOOLS is a collection of add-ons for OWL API</description>
 	<url>http://owlapitools.sourceforge.net/</url>
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>net.sourceforge.owlapi</groupId>
 			<artifactId>owlapi-apibinding</artifactId>
-			<version>4.0.1</version>
+			<version>[4,4.9.9]</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
@@ -152,7 +152,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>2.5.1</version>
+					<version>3.2</version>
 					<configuration>
 						<source>1.7</source>
 						<target>1.7</target>

--- a/suggestor/pom.xml
+++ b/suggestor/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>net.sourceforge.owlapi</groupId>
 		<artifactId>owlapitools-parent</artifactId>
-		<version>4.0.1</version>
+		<version>4.1.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 </project>


### PR DESCRIPTION
Changing package names feels like it ought to require  more than just going to 4.0.2-SNAPSHOT. 